### PR TITLE
alignment fix

### DIFF
--- a/app/code/community/TM/EasyCatalogImg/etc/system.xml
+++ b/app/code/community/TM/EasyCatalogImg/etc/system.xml
@@ -122,7 +122,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </show_image>
-                        <name_position translate="label">
+                        <name_below_image translate="label">
                             <label>Place names below images</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
@@ -130,7 +130,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
-                        </name_position>
+                        </name_below_image>
                         <image_width translate="label">
                             <label>Image width</label>
                             <frontend_type>text</frontend_type>

--- a/app/code/community/TM/EasyCatalogImg/etc/system.xml
+++ b/app/code/community/TM/EasyCatalogImg/etc/system.xml
@@ -122,6 +122,15 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </show_image>
+                        <name_position translate="label">
+                            <label>Place names below images</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>70</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </name_position>
                         <image_width translate="label">
                             <label>Image width</label>
                             <frontend_type>text</frontend_type>

--- a/app/code/community/TM/EasyCatalogImg/etc/widget.xml
+++ b/app/code/community/TM/EasyCatalogImg/etc/widget.xml
@@ -50,14 +50,14 @@
                 <source_model>adminhtml/system_config_source_yesno</source_model>
                 <value>1</value>
             </show_image>
-            <name_position translate="label">
+            <name_below_image translate="label">
                 <required>0</required>
                 <visible>1</visible>
                 <label>Place names below images</label>
                 <type>select</type>
                 <source_model>adminhtml/system_config_source_yesno</source_model>
                 <value>0</value>
-            </name_position>
+            </name_below_image>
             <image_width translate="label">
                 <required>0</required>
                 <visible>1</visible>

--- a/app/code/community/TM/EasyCatalogImg/etc/widget.xml
+++ b/app/code/community/TM/EasyCatalogImg/etc/widget.xml
@@ -50,6 +50,14 @@
                 <source_model>adminhtml/system_config_source_yesno</source_model>
                 <value>1</value>
             </show_image>
+            <name_position translate="label">
+                <required>0</required>
+                <visible>1</visible>
+                <label>Place names below images</label>
+                <type>select</type>
+                <source_model>adminhtml/system_config_source_yesno</source_model>
+                <value>0</value>
+            </name_position>
             <image_width translate="label">
                 <required>0</required>
                 <visible>1</visible>

--- a/app/design/frontend/base/default/template/tm/easycatalogimg/list.phtml
+++ b/app/design/frontend/base/default/template/tm/easycatalogimg/list.phtml
@@ -17,7 +17,7 @@ $height       = $this->getImageHeight();
 $width        = $this->getImageWidth();
 $maxCategoryCount    = $this->getCategoryCount();
 $maxSubcategoryCount = $this->getSubcategoryCount();
-$placeNamesBelowImages = $this->getNamePosition();
+$placeNamesBelowImages = $this->getNameBelowImage();
 $i = 0;
 ?>
 
@@ -29,7 +29,7 @@ $i = 0;
 
     <li class="item">
         <?php if (!$placeNamesBelowImages): ?>
-        <h5 class="category-name parent-category"><a href="<?php echo $_category->getUrl() ?>" title="<?php echo $this->htmlEscape($_category->getName()) ?>"><?php echo $this->htmlEscape($_category->getName()) ?></a></h5>
+            <h5 class="category-name parent-category"><a href="<?php echo $_category->getUrl() ?>" title="<?php echo $this->htmlEscape($_category->getName()) ?>"><?php echo $this->htmlEscape($_category->getName()) ?></a></h5>
         <?php endif; ?>
         <?php if ($showImage) : ?>
             <a href="<?php echo $_category->getUrl() ?>" title="<?php echo $this->htmlEscape($_category->getName()) ?>" class="product-image">
@@ -57,7 +57,7 @@ $i = 0;
             </a>
         <?php endif; ?>
         <?php if ($placeNamesBelowImages): ?>
-        <h5 class="category-name parent-category"><a href="<?php echo $_category->getUrl() ?>" title="<?php echo $this->htmlEscape($_category->getName()) ?>"><?php echo $this->htmlEscape($_category->getName()) ?></a></h5>
+            <h5 class="category-name parent-category"><a href="<?php echo $_category->getUrl() ?>" title="<?php echo $this->htmlEscape($_category->getName()) ?>"><?php echo $this->htmlEscape($_category->getName()) ?></a></h5>
         <?php endif; ?>
         <?php
         if ($maxSubcategoryCount) :

--- a/app/design/frontend/base/default/template/tm/easycatalogimg/list.phtml
+++ b/app/design/frontend/base/default/template/tm/easycatalogimg/list.phtml
@@ -17,6 +17,7 @@ $height       = $this->getImageHeight();
 $width        = $this->getImageWidth();
 $maxCategoryCount    = $this->getCategoryCount();
 $maxSubcategoryCount = $this->getSubcategoryCount();
+$placeNamesBelowImages = $this->getNamePosition();
 $i = 0;
 ?>
 
@@ -27,6 +28,9 @@ $i = 0;
     <?php if ($i >= $maxCategoryCount): break; endif; $i++; ?>
 
     <li class="item">
+        <?php if (!$placeNamesBelowImages): ?>
+        <h5 class="category-name parent-category"><a href="<?php echo $_category->getUrl() ?>" title="<?php echo $this->htmlEscape($_category->getName()) ?>"><?php echo $this->htmlEscape($_category->getName()) ?></a></h5>
+        <?php endif; ?>
         <?php if ($showImage) : ?>
             <a href="<?php echo $_category->getUrl() ?>" title="<?php echo $this->htmlEscape($_category->getName()) ?>" class="product-image">
                 <?php $imageUrl = $this->getImage($_category) ?>
@@ -52,7 +56,9 @@ $i = 0;
                 <?php endif; ?>
             </a>
         <?php endif; ?>
+        <?php if ($placeNamesBelowImages): ?>
         <h5 class="category-name parent-category"><a href="<?php echo $_category->getUrl() ?>" title="<?php echo $this->htmlEscape($_category->getName()) ?>"><?php echo $this->htmlEscape($_category->getName()) ?></a></h5>
+        <?php endif; ?>
         <?php
         if ($maxSubcategoryCount) :
             $j = 0;

--- a/app/design/frontend/base/default/template/tm/easycatalogimg/list.phtml
+++ b/app/design/frontend/base/default/template/tm/easycatalogimg/list.phtml
@@ -27,7 +27,6 @@ $i = 0;
     <?php if ($i >= $maxCategoryCount): break; endif; $i++; ?>
 
     <li class="item">
-        <h5 class="category-name parent-category"><a href="<?php echo $_category->getUrl() ?>" title="<?php echo $this->htmlEscape($_category->getName()) ?>"><?php echo $this->htmlEscape($_category->getName()) ?></a></h5>
         <?php if ($showImage) : ?>
             <a href="<?php echo $_category->getUrl() ?>" title="<?php echo $this->htmlEscape($_category->getName()) ?>" class="product-image">
                 <?php $imageUrl = $this->getImage($_category) ?>
@@ -53,6 +52,7 @@ $i = 0;
                 <?php endif; ?>
             </a>
         <?php endif; ?>
+        <h5 class="category-name parent-category"><a href="<?php echo $_category->getUrl() ?>" title="<?php echo $this->htmlEscape($_category->getName()) ?>"><?php echo $this->htmlEscape($_category->getName()) ?></a></h5>
         <?php
         if ($maxSubcategoryCount) :
             $j = 0;


### PR DESCRIPTION
Long category names break grid alignment.
Fix alignment issues by placing text below image.

